### PR TITLE
Docker in docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ $ footloose ssh node1
    62 ?        Ss     0:00 /usr/lib/systemd/systemd-logind
 ```
 
+## `footloose.yaml`
+
+`footloose config` creates a `footloose.yaml` configuration file that is then
+used by subsequent commands such as `create`, `delete` or `ssh`. If desired,
+the configuration file can be named differently and supplied with the
+`-c, --config` option.
+
+```console
+$ footloose config --replicas 3
+$ cat footloose.yaml
+cluster:
+  name: cluster
+  privateKey: cluster-key
+machines:
+- count: 3
+  spec:
+    image: quay.io/footloose/centos7
+    name: node%d
+```
+
+This configuration can naturally be edited by hand. The full list of
+available parameters are in [the reference documentation][pkg-config].
+
+[pkg-config]: https://godoc.org/github.com/dlespiau/footloose/pkg/config
+
 ## Under the hood
 
 Under the hood, *Container Machines* are just containers. They can be
@@ -79,6 +104,9 @@ CONTAINER ID    IMAGE                        COMMAND         NAMES
 1665288855f6    quay.io/footloose/centos7    "/sbin/init"    cluster-node1
 5134f80b733e    quay.io/footloose/centos7    "/sbin/init"    cluster-node0
 ```
+
+The container names are derived from `cluster.name` and
+`cluster.machines[].name`.
 
 They run `systemd` as PID 1, it's even possible to inspect the boot messages:
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,49 @@ available parameters are in [the reference documentation][pkg-config].
 
 [pkg-config]: https://godoc.org/github.com/dlespiau/footloose/pkg/config
 
+## Examples
+
+Interesting things can be done with `footloose`!
+
+## Running `dockerd` in Container Machines
+
+To run `dockerd` inside a docker container, two things are needed:
+
+- Run the container as privileged (we could probably do better! expose
+capabilities instead!).
+- Mount `/var/lib/docker` as volume, here an anonymous volume. This is
+because of a [limitations][dind] of what you can do with the overlay systems
+docker is setup to use.
+
+```yaml
+cluster:
+  name: cluster
+  privateKey: cluster-key
+machines:
+- count: 1
+  spec:
+    volumes:
+    - type: volume
+      destination: /var/lib/docker
+    image: quay.io/footloose/centos7
+    name: node%d
+    privileged: true
+```
+
+You can then install and run docker on the machine:
+
+```console
+$ footloose create
+$ footloose ssh node0
+# yum install -y docker iptables
+[...]
+# systemctl start docker
+# docker run busybox echo 'Hello, World!'
+Hello, World!
+```
+
+[dind]: https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
+
 ## Under the hood
 
 Under the hood, *Container Machines* are just containers. They can be

--- a/config.go
+++ b/config.go
@@ -28,6 +28,9 @@ func init() {
 	replicas := &defaultConfig.Machines[0].Count
 	configCmd.PersistentFlags().IntVarP(replicas, "replicas", "r", *replicas, "Number of machine replicas")
 
+	privileged := &defaultConfig.Machines[0].Spec.Privileged
+	configCmd.PersistentFlags().BoolVar(privileged, "privileged", *privileged, "Create privileged containers")
+
 	footloose.AddCommand(configCmd)
 }
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -115,6 +115,18 @@ func (c *Cluster) createMachine(machine *config.Machine, i int) error {
 		"-v", "/sys/fs/cgroup:/sys/fs/cgroup:ro",
 	}
 
+	for _, volume := range machine.Volumes {
+		mount := f("type=%s", volume.Type)
+		if volume.Source != "" {
+			mount += f(",src=%s", volume.Source)
+		}
+		mount += f(",dst=%s", volume.Destination)
+		if volume.ReadOnly {
+			mount += ",readonly"
+		}
+		runArgs = append(runArgs, "--mount", mount)
+	}
+
 	if machine.Privileged {
 		runArgs = append(runArgs, "--privileged")
 	}

--- a/pkg/config/machine.go
+++ b/pkg/config/machine.go
@@ -1,5 +1,21 @@
 package config
 
+// Volume is a volume that can be attached to a Machine.
+type Volume struct {
+	// Type is the volume type. One of "bind" or "volume".
+	Type string `json:"type"`
+	// Source is the volume source.
+	// With type=bind, the volume source is a directory or a file in the host
+	// filesystem.
+	// With type=volume, source is either the name of a docker volume or "" for
+	// anonymous volumes.
+	Source string `json:"source"`
+	// Destination is the mount point inside the container.
+	Destination string `json:"destination"`
+	// ReadOnly specifies if the volume should be read-only or not.
+	ReadOnly bool `json:"readOnly"`
+}
+
 // Machine is the machine configuration.
 type Machine struct {
 	// Name is the machine name. This is a format string with %d as the machine
@@ -12,4 +28,6 @@ type Machine struct {
 	// Privileged controls whether to start the Machine as a privileged container
 	// or not. Defaults to false.
 	Privileged bool `json:"privileged,omitempty"`
+	// Volumes is the list of volumes attached to this machine.
+	Volumes []Volume `json:"volumes,omitempty"`
 }

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -63,6 +63,10 @@ func (t *test) shouldSkip() bool {
 	return exists(t.file + ".skip")
 }
 
+func (t *test) isLong() bool {
+	return exists(t.file + ".long")
+}
+
 func (t *test) outputDir() string {
 	return t.file + ".got"
 }
@@ -196,6 +200,9 @@ func TestEndToEnd(t *testing.T) {
 	for _, file := range files {
 		test := newTest(file)
 		t.Run(test.name(), func(t *testing.T) {
+			if test.isLong() && testing.Short() {
+				t.Skip("Skipping long running test in short mode")
+			}
 			runTest(t, test)
 		})
 	}

--- a/tests/test-docker-in-docker.cmd
+++ b/tests/test-docker-in-docker.cmd
@@ -1,0 +1,6 @@
+footloose create --config %t.yaml
+footloose --config %t.yaml ssh node0 -- yum install -y docker iptables
+footloose --config %t.yaml ssh node0 systemctl start docker
+footloose --config %t.yaml ssh node0 docker pull busybox
+%out footloose --config %t.yaml ssh node0 docker run busybox echo success
+footloose delete --config %t.yaml

--- a/tests/test-docker-in-docker.golden.output
+++ b/tests/test-docker-in-docker.golden.output
@@ -1,0 +1,1 @@
+success

--- a/tests/test-docker-in-docker.yaml
+++ b/tests/test-docker-in-docker.yaml
@@ -1,0 +1,12 @@
+cluster:
+  name: test-docker-in-docker
+  privateKey: test-docker-in-docker-key
+machines:
+- count: 1
+  spec:
+    volumes:
+    - type: volume
+      destination: /var/lib/docker
+    image: quay.io/footloose/centos7
+    name: node%d
+    privileged: true


### PR DESCRIPTION
This PR introduces Volume support for container machines, which allows running docker in docker (/var/lib/docker cannot be itself already an overlay).

Fixes: #4 