### PR TITLE
 pkg/cluster/machine.go: Remove quotes from port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+cluster-key
+cluster-key.pub
 footloose
 footloose.yaml

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dlespiau/footloose
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect

--- a/pkg/cluster/machine.go
+++ b/pkg/cluster/machine.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/dlespiau/footloose/pkg/config"
 	"github.com/pkg/errors"
@@ -56,7 +57,8 @@ func (m *Machine) HostPort(containerPort int) (hostPort int, err error) {
 		m.ports = make(map[int]int)
 	}
 
-	m.ports[containerPort], err = strconv.Atoi(lines[0])
+	port := strings.Replace(lines[0], "'", "", -1)
+	m.ports[containerPort], err = strconv.Atoi(port)
 	if err != nil {
 		return -1, errors.Wrap(err, "hostport: failed to parse string to int")
 	}


### PR DESCRIPTION
Ran into the following error, this fixes it:
```
FATA[0000] hostport: failed to parse string to int: strconv.Atoi: parsing "'32768'": invalid syntax
```

No idea why the `go.mod` file was now updated, but I commited that?

cc @dlespiau 