### PR TITLE
Swap hostPort and containerPort

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -175,10 +175,10 @@ func (c *Cluster) createMachineRunArgs(machine *Machine, name string, i int) []s
 		if mapping.Address != "" {
 			publish += f("%s:", mapping.Address)
 		}
-		publish += f("%d", mapping.ContainerPort)
 		if mapping.HostPort != 0 {
-			publish += f(":%d", int(mapping.HostPort)+i)
+			publish += f("%d:", int(mapping.HostPort)+i)
 		}
+		publish += f("%d", mapping.ContainerPort)
 		if mapping.Protocol != "" {
 			publish += f("/%s", mapping.Protocol)
 		}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -33,16 +33,22 @@ func New(conf config.Config) *Cluster {
 	}
 }
 
+// NewFromYAML creates a new Cluster from a YAML serialization of its
+// configuration available in the provided string.
+func NewFromYAML(data []byte) (*Cluster, error) {
+	spec := config.Config{}
+	err := yaml.Unmarshal(data, &spec)
+	return New(spec), err
+}
+
 // NewFromFile creates a new Cluster from a YAML serialization of its
-// configuration.
+// configuration available in the provided file.
 func NewFromFile(path string) (*Cluster, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	spec := config.Config{}
-	err = yaml.Unmarshal(data, &spec)
-	return New(spec), err
+	return NewFromYAML(data)
 }
 
 // Save writes the Cluster configure to a file.

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -21,3 +21,48 @@ func TestMatchFilter(t *testing.T) {
 	filter.Write([]byte(refused))
 	assert.Equal(t, true, filter.matched)
 }
+
+func TestNewClusterWithHostPort(t *testing.T) {
+	cluster, err := NewFromYAML([]byte(`cluster:
+  name: cluster
+  privateKey: cluster-key
+machines:
+- count: 2
+  spec:
+    image: quay.io/footloose/centos7
+    name: node%d
+    portMappings:
+    - containerPort: 22
+      hostPort: 2222
+`))
+	assert.NoError(t, err)
+	assert.NotNil(t, cluster)
+	assert.Equal(t, 1, len(cluster.spec.Machines))
+	template := cluster.spec.Machines[0]
+	assert.Equal(t, 2, template.Count)
+	assert.Equal(t, 1, len(template.Spec.PortMappings))
+	portMapping := template.Spec.PortMappings[0]
+	assert.Equal(t, uint16(22), portMapping.ContainerPort)
+	assert.Equal(t, uint16(2222), portMapping.HostPort)
+
+	machine0 := cluster.machine(&template.Spec, 0)
+	args0 := cluster.createMachineRunArgs(machine0, machine0.ContainerName(), 0)
+	i := indexOf("-p", args0)
+	assert.NotEqual(t, -1, i)
+	assert.Equal(t, "2222:22", args0[i+1])
+
+	machine1 := cluster.machine(&template.Spec, 1)
+	args1 := cluster.createMachineRunArgs(machine1, machine1.ContainerName(), 1)
+	i = indexOf("-p", args1)
+	assert.NotEqual(t, -1, i)
+	assert.Equal(t, "2223:22", args1[i+1])
+}
+
+func indexOf(element string, array []string) int {
+	for k, v := range array {
+		if element == v {
+			return k
+		}
+	}
+	return -1 // element not found.
+}


### PR DESCRIPTION
Fixes #40.

Manual, end-to-end test in addition to the unit test included in the PR:
```console
$ footloose create
INFO[0000] Image: quay.io/footloose/centos7 present locally 
INFO[0000] Creating machine: cluster-node0 ...          
INFO[0001] Creating machine: cluster-node1 ...          

$ docker ps
CONTAINER ID        IMAGE                       COMMAND             CREATED             STATUS              PORTS                  NAMES
b3f100b6b6c1        quay.io/footloose/centos7   "/sbin/init"        2 seconds ago       Up 1 second         0.0.0.0:2223->22/tcp   cluster-node1
95b4054646d9        quay.io/footloose/centos7   "/sbin/init"        3 seconds ago       Up 2 seconds        0.0.0.0:2222->22/tcp   cluster-node0
```